### PR TITLE
Allow outputting to a different drive

### DIFF
--- a/acsuite/ffmpeg.py
+++ b/acsuite/ffmpeg.py
@@ -4,7 +4,7 @@ import string
 import tempfile
 
 from enum import Enum
-from shutil import which
+from shutil import which, move
 from subprocess import CalledProcessError, run
 from typing import Any, Dict, List, Literal, Optional, NamedTuple, Tuple, Union
 
@@ -347,7 +347,7 @@ class FFmpegAudio(FFmpeg):
                     raise ValueError("Received too many output filenames!")
                 if any([name == "index" for _, name, _, _ in string.Formatter().parse(outfile[0])]):
                     raise ValueError("Found an index format specifier in output filename, but 'combine' is True!")
-                os.rename(clipped, outfile[0].format(filename=filename))
+                move(clipped, outfile[0].format(filename=filename))
         finally:
             for p in partials:
                 os.remove(p) if os.path.isfile(p) else None


### PR DESCRIPTION
The current approach of `os.rename` does not allow moving the output file to a different device, this prevents running a script from `C:\Encodes\Someshow.vpy` (or a similarly arbitrary location on `/dev/sda1`) and then outputting the resulting trimmed file to `D:\Encodes\Someshow\audio.mkv` (or somewhere on `/dev/sdb2`).
This change turns that into `shutil.move`, which does allow for such move operations. If the move operation happens on the same filesystem, it will still internally call `os.rename`