### PR TITLE
Overhaul

### DIFF
--- a/acsuite/ffmpeg.py
+++ b/acsuite/ffmpeg.py
@@ -4,7 +4,7 @@ import string
 import tempfile
 
 from enum import Enum
-from shutil import which
+from shutil import which, move
 from subprocess import CalledProcessError, run
 from typing import Any, Dict, List, Literal, Optional, NamedTuple, Tuple, Union
 
@@ -347,7 +347,7 @@ class FFmpegAudio(FFmpeg):
                     raise ValueError("Received too many output filenames!")
                 if any([name == "index" for _, name, _, _ in string.Formatter().parse(outfile[0])]):
                     raise ValueError("Found an index format specifier in output filename, but 'combine' is True!")
-                os.rename(clipped, outfile[0].format(filename=filename))
+                move(clipped, outfile[0].format(filename=filename))
         finally:
             for p in partials:
                 os.remove(p) if os.path.isfile(p) else None

--- a/acsuite/ffmpeg.py
+++ b/acsuite/ffmpeg.py
@@ -103,15 +103,10 @@ class FFmpeg():
 
         :param search_path: Path to search for binaries.
         """
-        if search_path is None:
-            ffmpeg = which("ffmpeg")
-            ffprobe = which("ffprobe")
-        else:
-            search_path = os.path.dirname(search_path) if os.path.isfile(search_path) else search_path
-            ffprobe = os.path.join(os.path.dirname(search_path), "ffprobe")
-            ffmpeg = os.path.join(os.path.dirname(search_path), "ffmpeg")
+        ffmpeg = which("ffmpeg", path=search_path) or which("ffmpeg")
+        ffprobe = which("ffprobe", path=search_path) or which("ffprobe")
 
-        if ffmpeg is None or ffprobe is None or not os.path.isfile(ffmpeg) or not os.path.isfile(ffprobe):
+        if ffmpeg is None or ffprobe is None:
             raise FileNotFoundError(f"eztrim: ffmpeg/ffprobe executables not found in {search_path or 'PATH'}")
 
         self.ffmpeg_path = ffmpeg


### PR DESCRIPTION
Two small changes were made. The first is to allow the output to be on a different (logical) volume than the current working directory, for which `shutil.move` is required instead of the naïve `os.rename`. `os.rename` is still called internally if the move happens on the same (logical) volume. This is for cases when the current working directory is `C:\Users\Riven` (or some place on `/dev/sda1` on a UNIX-like system) and the output file is located in `D:\Encodes\output` (or some place on `/dev/sda2` or `/dev/sdb1`).
The second cleans up locating `ffmpeg` and `ffprobe` and reduces extraneous checking.